### PR TITLE
fix typo: Mycoromycota -> Mucoromycota in models.py

### DIFF
--- a/fungalmaterials/models.py
+++ b/fungalmaterials/models.py
@@ -45,7 +45,7 @@ class Species(models.Model):
         ('Basidiomycota', 'Basidiomycota'),
         ('Ascomycota', 'Ascomycota'),
         ('Blastocladiomycota', 'Blastocladiomycota'),
-        ('Mycoromycota', 'Mycoromycota'),
+        ('Mucoromycota', 'Mucoromycota'),
         ('Opisthosporidia', 'Opisthosporidia'))
     phylum = models.CharField(max_length=20, choices=phylum_choice, blank=True)
 


### PR DESCRIPTION
Fixed typo on line 48 of `fungalmaterials/models.py`.

Changed `Mycoromycota` to `Mucoromycota`.